### PR TITLE
Fixed NEXTVAL Operator for MS SQLServer (starting with 2012)

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/SQLServer2012Templates.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/SQLServer2012Templates.java
@@ -64,6 +64,7 @@ public class SQLServer2012Templates extends SQLServerTemplates {
 
     protected SQLServer2012Templates(Set<String> keywords, char escape, boolean quote) {
         super(keywords, escape, quote);
+        add(SQLOps.NEXTVAL, "next value for {0s}");
     }
 
     @Override


### PR DESCRIPTION
Hi,
The nextval operator is wrong for SQL Server (2012). It should be "next value for ". 
See https://docs.microsoft.com/en-us/sql/t-sql/functions/next-value-for-transact-sql

Thanks.
theodor